### PR TITLE
Exporting package api into __init__.py

### DIFF
--- a/diff_tool/__init__.py
+++ b/diff_tool/__init__.py
@@ -1,0 +1,3 @@
+from .diff import DiffTool
+
+__all__ = ['DiffTool']


### PR DESCRIPTION
Hi,

Thanks for this great tool, is it possible to export the package api main class into ``__init__.py``?
Just to avoid the long path: ``import diff_tool.diff.DiffTool``

Br,
Theodore G.